### PR TITLE
set sort as default option

### DIFF
--- a/ios1.bst
+++ b/ios1.bst
@@ -1982,7 +1982,7 @@ FUNCTION {initialize.et.al.char.used}
 
 %%%%% setting default options
 FUNCTION {set.default.opt}
-{"unsort" 'list.string :=}
+{"sort" 'list.string :=}
 
 EXECUTE {set.default.opt}
 


### PR DESCRIPTION
It is required by the journal but not set as default in the latex style file. I spent a lot of time on that, hoping that it would be useful for others.